### PR TITLE
feat(complaint-selector): implement complaint search suggestions popover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ test.js
 *.njsproj
 *.sln
 *.sw?
+.*

--- a/src/data/complaints_catalog.ts
+++ b/src/data/complaints_catalog.ts
@@ -1,0 +1,79 @@
+import type { MedicalComplaint } from "@/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Master catalog for the "Add New Complaint" popover.
+// These are NOT patient-specific records — they are suggestion seeds that get
+// turned into a real EXISTING/NEW complaint when the doctor picks one.
+// Each entry carries a `region` tag so the RegionChips filter can work.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const COMPLAINT_CATALOG: MedicalComplaint[] = [
+  // ── Spine ──────────────────────────────────────────────────────────────────
+  { id: "CAT_S01", title: "Cervical Spondylosis",          isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S02", title: "Lumbar Disc Herniation (L4–L5)", isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S03", title: "Chronic Lower Back Pain",        isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S04", title: "Lumbar Spondylosis",             isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S05", title: "Sciatica",                       isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S06", title: "Thoracic Outlet Syndrome",       isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S07", title: "Spondylolisthesis",              isActive: true, type: "EXISTING", region: "Spine" },
+  { id: "CAT_S08", title: "Spinal Stenosis",                isActive: true, type: "EXISTING", region: "Spine" },
+
+  // ── Shoulder ───────────────────────────────────────────────────────────────
+  { id: "CAT_SH01", title: "Frozen Shoulder (Adhesive Capsulitis)", isActive: true, type: "EXISTING", region: "Shoulder" },
+  { id: "CAT_SH02", title: "Rotator Cuff Tear",             isActive: true, type: "EXISTING", region: "Shoulder" },
+  { id: "CAT_SH03", title: "Shoulder Impingement Syndrome", isActive: true, type: "EXISTING", region: "Shoulder" },
+  { id: "CAT_SH04", title: "AC Joint Sprain",               isActive: true, type: "EXISTING", region: "Shoulder" },
+  { id: "CAT_SH05", title: "Biceps Tendinopathy",           isActive: true, type: "EXISTING", region: "Shoulder" },
+
+  // ── Knee ───────────────────────────────────────────────────────────────────
+  { id: "CAT_K01", title: "Post-Op ACL Reconstruction Rehab", isActive: true, type: "EXISTING", region: "Knee" },
+  { id: "CAT_K02", title: "Patellofemoral Pain Syndrome",   isActive: true, type: "EXISTING", region: "Knee" },
+  { id: "CAT_K03", title: "Meniscus Tear",                  isActive: true, type: "EXISTING", region: "Knee" },
+  { id: "CAT_K04", title: "Osteoarthritis – Knee",          isActive: true, type: "EXISTING", region: "Knee" },
+  { id: "CAT_K05", title: "IT Band Syndrome",               isActive: true, type: "EXISTING", region: "Knee" },
+  { id: "CAT_K06", title: "Patellar Tendinopathy",          isActive: true, type: "EXISTING", region: "Knee" },
+
+  // ── Hip ────────────────────────────────────────────────────────────────────
+  { id: "CAT_H01", title: "Hip Osteoarthritis",             isActive: true, type: "EXISTING", region: "Hip" },
+  { id: "CAT_H02", title: "Hip Bursitis (Trochanteric)",    isActive: true, type: "EXISTING", region: "Hip" },
+  { id: "CAT_H03", title: "Groin Strain",                   isActive: true, type: "EXISTING", region: "Hip" },
+  { id: "CAT_H04", title: "Piriformis Syndrome",            isActive: true, type: "EXISTING", region: "Hip" },
+  { id: "CAT_H05", title: "Hip Labral Tear",                isActive: true, type: "EXISTING", region: "Hip" },
+
+  // ── Elbow / Wrist / Hand ───────────────────────────────────────────────────
+  { id: "CAT_E01", title: "Tennis Elbow (Lateral Epicondylitis)",  isActive: true, type: "EXISTING", region: "Elbow" },
+  { id: "CAT_E02", title: "Golfer's Elbow (Medial Epicondylitis)", isActive: true, type: "EXISTING", region: "Elbow" },
+  { id: "CAT_E03", title: "Carpal Tunnel Syndrome",         isActive: true, type: "EXISTING", region: "Elbow" },
+  { id: "CAT_E04", title: "De Quervain's Tenosynovitis",    isActive: true, type: "EXISTING", region: "Elbow" },
+  { id: "CAT_E05", title: "Wrist Sprain",                   isActive: true, type: "EXISTING", region: "Elbow" },
+
+  // ── Ankle / Foot ───────────────────────────────────────────────────────────
+  { id: "CAT_A01", title: "Ankle Sprain (Lateral)",         isActive: true, type: "EXISTING", region: "Ankle" },
+  { id: "CAT_A02", title: "Plantar Fasciitis",              isActive: true, type: "EXISTING", region: "Ankle" },
+  { id: "CAT_A03", title: "Achilles Tendinopathy",          isActive: true, type: "EXISTING", region: "Ankle" },
+  { id: "CAT_A04", title: "Post-Op Ankle Fracture Rehab",   isActive: true, type: "EXISTING", region: "Ankle" },
+  { id: "CAT_A05", title: "Tibialis Posterior Tendinopathy",isActive: true, type: "EXISTING", region: "Ankle" },
+
+  // ── Neuro / Head ──────────────────────────────────────────────────────────
+  { id: "CAT_N01", title: "Migraine (Cervicogenic)",        isActive: true, type: "EXISTING", region: "Neuro" },
+  { id: "CAT_N02", title: "Bell's Palsy",                   isActive: true, type: "EXISTING", region: "Neuro" },
+  { id: "CAT_N03", title: "Stroke Rehabilitation",          isActive: true, type: "EXISTING", region: "Neuro" },
+  { id: "CAT_N04", title: "Peripheral Neuropathy",          isActive: true, type: "EXISTING", region: "Neuro" },
+  { id: "CAT_N05", title: "Parkinson's Disease – Physio",   isActive: true, type: "EXISTING", region: "Neuro" },
+];
+
+// Derive unique regions from the catalog for the chips list.
+// We define the order explicitly so "All" is always first and the rest are
+// sorted consistently — avoids relying on insertion order of a Set.
+export const CATALOG_REGIONS = [
+  "All",
+  "Spine",
+  "Shoulder",
+  "Knee",
+  "Hip",
+  "Elbow",
+  "Ankle",
+  "Neuro",
+] as const;
+
+export type CatalogRegion = (typeof CATALOG_REGIONS)[number];

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib";
+import { COMPLAINT_CATALOG, CATALOG_REGIONS, type CatalogRegion } from "@/data/complaints_catalog";
+import type { MedicalComplaint } from "@/types";
+
+interface CatalogSearchPopoverProps {
+  /** The input element to anchor the popover under. */
+  anchorRef: React.RefObject<HTMLElement | null>;
+  /** Current text in the search input — used to filter catalog entries. */
+  query: string;
+  /** Whether the popover should be visible. */
+  isOpen: boolean;
+  /** Called when the user picks an item from the catalog.
+   *  The parent will turn this into a real active complaint. */
+  onSelect: (complaint: MedicalComplaint) => void;
+  /** Called when we decide the popover should close (click-outside, Escape). */
+  onClose: () => void;
+  /** IDs that are already active on the patient — we grey these out. */
+  existingIds: Set<string>;
+}
+
+export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
+  anchorRef,
+  query,
+  isOpen,
+  onSelect,
+  onClose,
+  existingIds,
+}) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [selectedRegion, setSelectedRegion] = useState<CatalogRegion>("All");
+
+  // ── Position popover directly below the anchor ──────────────────────────────
+  const [coords, setCoords] = useState({ top: 0, left: 0, width: 0 });
+
+  const updateCoords = useCallback(() => {
+    if (!anchorRef.current) return;
+    const rect = anchorRef.current.getBoundingClientRect();
+    setCoords({
+      // position:fixed is viewport-relative — getBoundingClientRect() is already
+      // in viewport coords, so we must NOT add scrollY/scrollX here.
+      top: rect.bottom + 6, // 6px gap below the input
+      left: rect.left,
+      width: rect.width,
+    });
+  }, [anchorRef]);
+
+  // Recalculate on open and on scroll/resize so the popover tracks the input.
+  useEffect(() => {
+    if (!isOpen) return;
+    updateCoords();
+    window.addEventListener("resize", updateCoords);
+    window.addEventListener("scroll", updateCoords, true);
+    return () => {
+      window.removeEventListener("resize", updateCoords);
+      window.removeEventListener("scroll", updateCoords, true);
+    };
+  }, [isOpen, updateCoords]);
+
+  // ── Click-outside detection ──────────────────────────────────────────────────
+  // We listen on mousedown (not click) so we can intercept before focus changes.
+  // We intentionally keep the popover open when the user clicks inside it OR
+  // on the anchor input itself (the parent controls `isOpen` via focus).
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const insidePopover = popoverRef.current?.contains(target);
+      const insideAnchor = anchorRef.current?.contains(target);
+      if (!insidePopover && !insideAnchor) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [isOpen, anchorRef, onClose]);
+
+  // ── Reset region filter when the user clears the query ───────────────────
+  useEffect(() => {
+    if (!query) setSelectedRegion("All");
+  }, [query]);
+
+  // ── Filter logic ────────────────────────────────────────────────────────────
+  const filteredItems = useMemo(() => {
+    return COMPLAINT_CATALOG.filter((c) => {
+      const matchesRegion = selectedRegion === "All" || c.region === selectedRegion;
+      const matchesQuery = !query || c.title.toLowerCase().includes(query.toLowerCase());
+      return matchesRegion && matchesQuery;
+    });
+  }, [query, selectedRegion]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      ref={popoverRef}
+      // Positioned fixed so it escapes any overflow:hidden parents.
+      // z-50 puts it above modals/drawers at z-40.
+      style={{
+        position: "fixed",
+        top: coords.top,
+        left: coords.left,
+        width: coords.width,
+        zIndex: 50,
+      }}
+      className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl shadow-2xl overflow-hidden"
+    >
+      {/* ── Region chips ─────────────────────────────────────────────────── */}
+      {/* Scrollable horizontal strip — no scrollbar visible (hide-scrollbar util) */}
+      <div className="flex gap-1.5 overflow-x-auto px-3 pt-3 pb-2 hide-scrollbar">
+        {CATALOG_REGIONS.map((region) => (
+          <button
+            key={region}
+            type="button"
+            // Prevent the mousedown from bubbling up and triggering onClose
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setSelectedRegion(region)}
+            className={cn(
+              "shrink-0 px-3 py-1 rounded-full text-xs font-semibold border transition-all",
+              selectedRegion === region
+                ? "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 border-transparent"
+                : "bg-transparent border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:border-zinc-400 dark:hover:border-zinc-500"
+            )}
+          >
+            {region}
+          </button>
+        ))}
+      </div>
+
+      {/* Thin divider between chips and list */}
+      <div className="h-px bg-zinc-100 dark:bg-zinc-800 mx-3" />
+
+      {/* ── Filtered results list ────────────────────────────────────────── */}
+      {/* ~2.5 cards tall; each row is ~44px, so ~2.5 * 44 ≈ 110px.
+          max-h-28 ≈ 112px — close enough without a magic number. */}
+      <div className="max-h-28 overflow-y-auto">
+        {filteredItems.length === 0 ? (
+          <p className="px-4 py-3 text-xs text-zinc-400 dark:text-zinc-500">
+            No matches — type a custom complaint and press Enter
+          </p>
+        ) : (
+          filteredItems.map((item) => {
+            const alreadyAdded = existingIds.has(item.id);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                // Prevent blur on the search input from firing before onClick
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => !alreadyAdded && onSelect(item)}
+                disabled={alreadyAdded}
+                className={cn(
+                  "w-full text-left px-4 py-2.5 flex items-center justify-between transition-colors",
+                  alreadyAdded
+                    ? "opacity-40 cursor-not-allowed"
+                    : "hover:bg-zinc-50 dark:hover:bg-zinc-800 cursor-pointer"
+                )}
+              >
+                <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100 leading-tight">
+                  {item.title}
+                </span>
+                {item.region && (
+                  <span className="ml-2 shrink-0 text-[10px] text-zinc-400 dark:text-zinc-500 font-medium uppercase tracking-wide">
+                    {item.region}
+                  </span>
+                )}
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -107,6 +107,16 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
     });
   }, [query, selectedRegion, existingIds]);
 
+  // Decides whether to show a helper suggestion when a search term has no matches
+  // in the currently selected region, but matches exist in other regions.
+  // We use useMemo to avoid re-running this search on every render when dependencies are stable.
+  const hasMatchesInOtherRegions = useMemo(() => {
+    if (selectedRegion === "All" || !query) return false;
+    return COMPLAINT_CATALOG.some(
+      (c) => c.region !== selectedRegion && c.title.toLowerCase().includes(query.toLowerCase())
+    );
+  }, [query, selectedRegion]);
+
   // C3: Notify parent component when the filtered list of items changes.
   // We use a ref to track the last structural state of the list and perform an ID-based comparison.
   // This is a trade-off that prevents triggering parent state updates on every render cycle caused by
@@ -175,7 +185,13 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
       >
         {filteredItems.length === 0 ? (
           <p className="px-4 py-3 text-xs text-zinc-400 dark:text-zinc-500">
-            No matches — type a custom complaint and press Enter
+            {hasMatchesInOtherRegions ? (
+              <span>
+                No matches in <span className="font-semibold text-zinc-600 dark:text-zinc-400">{selectedRegion}</span>. Try switching to "All" regions.
+              </span>
+            ) : (
+              "No matches found"
+            )}
           </p>
         ) : (
           filteredItems.map((item, idx) => {

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -18,6 +18,15 @@ interface CatalogSearchPopoverProps {
   onClose: () => void;
   /** IDs that are already active on the patient — we grey these out. */
   existingIds: Set<string>;
+
+  // C3 accessibility properties lifted to the parent component for unified React event handling:
+  focusedIndex: number;
+  listboxId: string;
+  onFilteredItemsChange: (items: MedicalComplaint[]) => void;
+
+  // C3: Lifted region state and callback to handle keyboard nav in index.tsx
+  selectedRegion: CatalogRegion;
+  onRegionChange: (region: CatalogRegion) => void;
 }
 
 export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
@@ -27,9 +36,13 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
   onSelect,
   onClose,
   existingIds,
+  focusedIndex,
+  listboxId,
+  onFilteredItemsChange,
+  selectedRegion,
+  onRegionChange,
 }) => {
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [selectedRegion, setSelectedRegion] = useState<CatalogRegion>("All");
 
   // ── Position popover directly below the anchor ──────────────────────────────
   const [coords, setCoords] = useState({ top: 0, left: 0, width: 0 });
@@ -59,9 +72,6 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
   }, [isOpen, updateCoords]);
 
   // ── Click-outside detection ──────────────────────────────────────────────────
-  // We listen on mousedown (not click) so we can intercept before focus changes.
-  // We intentionally keep the popover open when the user clicks inside it OR
-  // on the anchor input itself (the parent controls `isOpen` via focus).
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: MouseEvent) => {
@@ -76,19 +86,43 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
     return () => document.removeEventListener("mousedown", handler);
   }, [isOpen, anchorRef, onClose]);
 
-  // ── Reset region filter when the user clears the query ───────────────────
-  useEffect(() => {
-    if (!query) setSelectedRegion("All");
-  }, [query]);
 
-  // ── Filter logic ────────────────────────────────────────────────────────────
+
+  // ── Filter & Sort logic ──────────────────────────────────────────────────────
   const filteredItems = useMemo(() => {
-    return COMPLAINT_CATALOG.filter((c) => {
+    const items = COMPLAINT_CATALOG.filter((c) => {
       const matchesRegion = selectedRegion === "All" || c.region === selectedRegion;
       const matchesQuery = !query || c.title.toLowerCase().includes(query.toLowerCase());
       return matchesRegion && matchesQuery;
     });
-  }, [query, selectedRegion]);
+
+    // Sort already-selected items to the end of the list so they don't clutter the popover.
+    // We sort already-added elements lower than available ones so that selectable items group at the top.
+    // We copy the filtered array first to prevent mutating the shared/cache array ref in React state.
+    return [...items].sort((a, b) => {
+      const aAdded = existingIds.has(a.id);
+      const bAdded = existingIds.has(b.id);
+      if (aAdded === bAdded) return 0;
+      return aAdded ? 1 : -1;
+    });
+  }, [query, selectedRegion, existingIds]);
+
+  // C3: Notify parent component when the filtered list of items changes.
+  // We use a ref to track the last structural state of the list and perform an ID-based comparison.
+  // This is a trade-off that prevents triggering parent state updates on every render cycle caused by
+  // referential instability of props (like existingIds which is recreated as a new Set on each parent render).
+  // Without this guard, parent state updates would run on every keystroke/arrow keydown and reset focusedIndex back to 0.
+  const lastFilteredItemsRef = useRef<MedicalComplaint[]>([]);
+  useEffect(() => {
+    const hasChanged =
+      filteredItems.length !== lastFilteredItemsRef.current.length ||
+      filteredItems.some((item, idx) => item.id !== lastFilteredItemsRef.current[idx]?.id);
+
+    if (hasChanged) {
+      lastFilteredItemsRef.current = filteredItems;
+      onFilteredItemsChange(filteredItems);
+    }
+  }, [filteredItems, onFilteredItemsChange]);
 
   if (!isOpen) return null;
 
@@ -115,7 +149,7 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
             type="button"
             // Prevent the mousedown from bubbling up and triggering onClose
             onMouseDown={(e) => e.preventDefault()}
-            onClick={() => setSelectedRegion(region)}
+            onClick={() => onRegionChange(region)}
             className={cn(
               "shrink-0 px-3 py-1 rounded-full text-xs font-semibold border transition-all",
               selectedRegion === region
@@ -134,43 +168,90 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
       {/* ── Filtered results list ────────────────────────────────────────── */}
       {/* ~2.5 cards tall; each row is ~44px, so ~2.5 * 44 ≈ 110px.
           max-h-28 ≈ 112px — close enough without a magic number. */}
-      <div className="max-h-28 overflow-y-auto">
+      <div
+        id={listboxId}
+        role="listbox"
+        className="max-h-28 overflow-y-auto"
+      >
         {filteredItems.length === 0 ? (
           <p className="px-4 py-3 text-xs text-zinc-400 dark:text-zinc-500">
-            No matches found
+            No matches — type a custom complaint and press Enter
           </p>
         ) : (
-          filteredItems.map((item) => {
+          filteredItems.map((item, idx) => {
             const alreadyAdded = existingIds.has(item.id);
+            const isFocused = idx === focusedIndex;
             return (
-              <button
+              <CatalogItem
                 key={item.id}
-                type="button"
-                // Prevent blur on the search input from firing before onClick
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => !alreadyAdded && onSelect(item)}
-                disabled={alreadyAdded}
-                className={cn(
-                  "w-full text-left px-4 py-2.5 flex items-center justify-between transition-colors",
-                  alreadyAdded
-                    ? "opacity-40 cursor-not-allowed"
-                    : "hover:bg-zinc-50 dark:hover:bg-zinc-800 cursor-pointer"
-                )}
-              >
-                <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100 leading-tight">
-                  {item.title}
-                </span>
-                {item.region && (
-                  <span className="ml-2 shrink-0 text-[10px] text-zinc-400 dark:text-zinc-500 font-medium uppercase tracking-wide">
-                    {item.region}
-                  </span>
-                )}
-              </button>
+                item={item}
+                isFocused={isFocused}
+                alreadyAdded={alreadyAdded}
+                onSelect={onSelect}
+                listboxId={listboxId}
+                index={idx}
+              />
             );
           })
         )}
       </div>
     </div>,
     document.body
+  );
+};
+
+interface CatalogItemProps {
+  item: MedicalComplaint;
+  isFocused: boolean;
+  alreadyAdded: boolean;
+  onSelect: (item: MedicalComplaint) => void;
+  listboxId: string;
+  index: number;
+}
+
+const CatalogItem: React.FC<CatalogItemProps> = ({
+  item,
+  isFocused,
+  alreadyAdded,
+  onSelect,
+  listboxId,
+  index,
+}) => {
+  const itemRef = useRef<HTMLButtonElement>(null);
+
+  // C3: Align with the Daily Ledger Search suggestion list.
+  // We scroll the item into view using smooth scrolling and nearest alignment when it gets focused via keyboard.
+  useEffect(() => {
+    if (isFocused && itemRef.current) {
+      itemRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [isFocused]);
+
+  return (
+    <button
+      ref={itemRef}
+      id={`${listboxId}-option-${index}`}
+      role="option"
+      aria-selected={isFocused}
+      aria-disabled={alreadyAdded ? "true" : undefined}
+      type="button"
+      // Prevent focus transfer from input to button during clicking
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => !alreadyAdded && onSelect(item)}
+      className={cn(
+        "w-full text-left px-4 py-2.5 flex items-center justify-between transition-colors",
+        alreadyAdded ? "opacity-40 cursor-not-allowed" : "cursor-pointer",
+        isFocused ? "bg-zinc-50 dark:bg-zinc-800" : "hover:bg-zinc-50 dark:hover:bg-zinc-800"
+      )}
+    >
+      <span className="text-sm font-medium text-zinc-800 dark:text-zinc-100 leading-tight">
+        {item.title}
+      </span>
+      {item.region && (
+        <span className="ml-2 shrink-0 text-[10px] text-zinc-400 dark:text-zinc-500 font-medium uppercase tracking-wide">
+          {item.region}
+        </span>
+      )}
+    </button>
   );
 };

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -137,7 +137,7 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
       <div className="max-h-28 overflow-y-auto">
         {filteredItems.length === 0 ? (
           <p className="px-4 py-3 text-xs text-zinc-400 dark:text-zinc-500">
-            No matches — type a custom complaint and press Enter
+            No matches found
           </p>
         ) : (
           filteredItems.map((item) => {

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -19,12 +19,12 @@ interface CatalogSearchPopoverProps {
   /** IDs that are already active on the patient — we grey these out. */
   existingIds: Set<string>;
 
-  // C3 accessibility properties lifted to the parent component for unified React event handling:
+  // accessibility properties lifted to the parent component for unified React event handling:
   focusedIndex: number;
   listboxId: string;
   onFilteredItemsChange: (items: MedicalComplaint[]) => void;
 
-  // C3: Lifted region state and callback to handle keyboard nav in index.tsx
+  // Lifted region state and callback to handle keyboard nav in index.tsx
   selectedRegion: CatalogRegion;
   onRegionChange: (region: CatalogRegion) => void;
 }

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -57,11 +57,10 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
       left: rect.left,
       width: rect.width,
     });
-    // Empty dependency array is correct here. Even though anchorRef is a prop, the ref object's 
-    // reference is stable. More importantly, ref.current is accessed at execution-time (run-time) 
-    // rather than captured at definition-time (like state variables). Thus, no recreation is needed 
-    // when the DOM element in the ref changes.
-  }, []);
+    // Empty dependency array was technically correct because the ref object's reference is stable and
+    // ref.current is accessed at execution-time. However, since anchorRef is passed as a prop, ESLint 
+    // and the React Compiler cannot guarantee its stability statically, so we list it in dependencies to satisfy them.
+  }, [anchorRef]);
 
   // Recalculate on open and on scroll/resize so the popover tracks the input.
   useEffect(() => {
@@ -121,7 +120,7 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
     );
   }, [query, selectedRegion]);
 
-  // C3: Notify parent component when the filtered list of items changes.
+  // Notify parent component when the filtered list of items changes.
   // We use a ref to track the last structural state of the list and perform an ID-based comparison.
   // This is a trade-off that prevents triggering parent state updates on every render cycle caused by
   // referential instability of props (like existingIds which is recreated as a new Set on each parent render).
@@ -239,7 +238,7 @@ const CatalogItem: React.FC<CatalogItemProps> = ({
 }) => {
   const itemRef = useRef<HTMLButtonElement>(null);
 
-  // C3: Align with the Daily Ledger Search suggestion list.
+  // Align with the Daily Ledger Search suggestion list.
   // We scroll the item into view using smooth scrolling and nearest alignment when it gets focused via keyboard.
   useEffect(() => {
     if (isFocused && itemRef.current) {

--- a/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
+++ b/src/features/visit/ComplaintSelector/components/CatalogSearchPopover.tsx
@@ -57,7 +57,11 @@ export const CatalogSearchPopover: React.FC<CatalogSearchPopoverProps> = ({
       left: rect.left,
       width: rect.width,
     });
-  }, [anchorRef]);
+    // Empty dependency array is correct here. Even though anchorRef is a prop, the ref object's 
+    // reference is stable. More importantly, ref.current is accessed at execution-time (run-time) 
+    // rather than captured at definition-time (like state variables). Thus, no recreation is needed 
+    // when the DOM element in the ref changes.
+  }, []);
 
   // Recalculate on open and on scroll/resize so the popover tracks the input.
   useEffect(() => {

--- a/src/features/visit/ComplaintSelector/components/ComplaintItem.tsx
+++ b/src/features/visit/ComplaintSelector/components/ComplaintItem.tsx
@@ -19,7 +19,7 @@ export const ComplaintItem: React.FC<ComplaintItemProps> = ({
     <div
         onClick={() => onToggle(complaint.id)}
         className={cn(
-            "flex items-center p-4 rounded-lg border cursor-pointer transition-all group",
+            "flex items-center px-4 py-3 rounded-lg border cursor-pointer transition-all group",
             isSelected
                 ? "bg-zinc-100 border-zinc-900 dark:bg-zinc-900 dark:border-white"
                 : "bg-white border-zinc-200 dark:bg-black dark:border-zinc-800 hover:border-zinc-400 dark:hover:border-zinc-600"

--- a/src/features/visit/ComplaintSelector/components/NewComplaintInput.tsx
+++ b/src/features/visit/ComplaintSelector/components/NewComplaintInput.tsx
@@ -1,51 +1,65 @@
+import { forwardRef } from "react";
 import { cn } from "@/lib";
-import { PlusIcon } from "lucide-react";
+import { PlusIcon, SearchIcon } from "lucide-react";
 
 interface NewComplaintInputProps {
   value: string;
   onChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onAdd: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  onClick?: () => void;
 }
 
-export const NewComplaintInput: React.FC<NewComplaintInputProps> = ({
-  value,
-  onChange,
-  onKeyDown,
-  onAdd,
-}) => (
-  <label
-    htmlFor="new_complaint"
-    className={cn(
-      "flex items-center p-4 rounded-lg border-2 border-dashed cursor-text",
-      "border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/30",
-      "hover:border-zinc-600 dark:hover:border-zinc-400",
-      "hover:bg-zinc-100 dark:hover:bg-zinc-800/50",
-      "focus-within:border-zinc-600 dark:focus-within:border-zinc-400"
-    )}
-  >
-    <PlusIcon className="w-5 h-5 text-zinc-400 dark:text-zinc-500 mr-4" />
-    <input
-      id="new_complaint"
-      type="text"
-      value={value}
-      onChange={(e) => onChange(e.currentTarget.value)}
-      onKeyDown={onKeyDown}
-      placeholder="Report new issue (e.g. Knee Pain)..."
-      className="flex-1 bg-transparent border-none outline-none text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 font-medium"
-    />
-    <button
-      type="button"
-      title="Add New Complaint"
-      onClick={onAdd}
-      disabled={!value.trim()}
+// forwardRef so the parent can pass anchorRef to this element —
+// the CatalogSearchPopover uses it to calculate its position.
+export const NewComplaintInput = forwardRef<HTMLLabelElement, NewComplaintInputProps>(
+  ({ value, onChange, onKeyDown, onAdd, onFocus, onBlur, onClick }, ref) => (
+    <label
+      ref={ref}
+      htmlFor="new_complaint"
       className={cn(
-        "p-2 rounded bg-zinc-200 dark:bg-zinc-800 ",
-        "hover:bg-zinc-300 dark:hover:bg-zinc-700",
-        "text-zinc-600 dark:text-zinc-300 disabled:opacity-50"
+        "flex items-center px-4 py-3 rounded-lg border-2 border-dashed cursor-text",
+        "border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/30",
+        "hover:border-zinc-600 dark:hover:border-zinc-400",
+        "hover:bg-zinc-100 dark:hover:bg-zinc-800/50",
+        // When the popover is open the input is focused — highlight the border
+        "focus-within:border-zinc-600 dark:focus-within:border-zinc-400"
       )}
     >
-      <PlusIcon className="w-4 h-4" />
-    </button>
-  </label>
+      {/* Use SearchIcon instead of PlusIcon to signal "search catalog" intent */}
+      <SearchIcon className="w-5 h-5 text-zinc-400 dark:text-zinc-500 mr-4 shrink-0" />
+      <input
+        id="new_complaint"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        onKeyDown={onKeyDown}
+        onFocus={onFocus}
+        onClick={onClick}
+        // onBlur fires before the popover's onMouseDown can capture the click,
+        // so we intentionally do NOT close the popover here — the popover's own
+        // click-outside detector handles that correctly.
+        onBlur={onBlur}
+        placeholder="Search or add new complaint..."
+        className="flex-1 bg-transparent border-none outline-none text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 font-medium text-sm"
+      />
+      <button
+        type="button"
+        title="Add New Complaint"
+        onClick={onAdd}
+        disabled={!value.trim()}
+        className={cn(
+          "p-2 rounded bg-zinc-200 dark:bg-zinc-800",
+          "hover:bg-zinc-300 dark:hover:bg-zinc-700",
+          "text-zinc-600 dark:text-zinc-300 disabled:opacity-50"
+        )}
+      >
+        <PlusIcon className="w-4 h-4" />
+      </button>
+    </label>
+  )
 );
+
+NewComplaintInput.displayName = "NewComplaintInput";

--- a/src/features/visit/ComplaintSelector/components/NewComplaintInput.tsx
+++ b/src/features/visit/ComplaintSelector/components/NewComplaintInput.tsx
@@ -1,12 +1,11 @@
 import { forwardRef } from "react";
 import { cn } from "@/lib";
-import { PlusIcon, SearchIcon } from "lucide-react";
+import { SearchIcon } from "lucide-react";
 
 interface NewComplaintInputProps {
   value: string;
   onChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
-  onAdd: () => void;
   onFocus: () => void;
   onBlur: () => void;
   onClick?: () => void;
@@ -15,7 +14,7 @@ interface NewComplaintInputProps {
 // forwardRef so the parent can pass anchorRef to this element —
 // the CatalogSearchPopover uses it to calculate its position.
 export const NewComplaintInput = forwardRef<HTMLLabelElement, NewComplaintInputProps>(
-  ({ value, onChange, onKeyDown, onAdd, onFocus, onBlur, onClick }, ref) => (
+  ({ value, onChange, onKeyDown, onFocus, onBlur, onClick }, ref) => (
     <label
       ref={ref}
       htmlFor="new_complaint"
@@ -42,22 +41,9 @@ export const NewComplaintInput = forwardRef<HTMLLabelElement, NewComplaintInputP
         // so we intentionally do NOT close the popover here — the popover's own
         // click-outside detector handles that correctly.
         onBlur={onBlur}
-        placeholder="Search or add new complaint..."
+        placeholder="Search complaints..."
         className="flex-1 bg-transparent border-none outline-none text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 font-medium text-sm"
       />
-      <button
-        type="button"
-        title="Add New Complaint"
-        onClick={onAdd}
-        disabled={!value.trim()}
-        className={cn(
-          "p-2 rounded bg-zinc-200 dark:bg-zinc-800",
-          "hover:bg-zinc-300 dark:hover:bg-zinc-700",
-          "text-zinc-600 dark:text-zinc-300 disabled:opacity-50"
-        )}
-      >
-        <PlusIcon className="w-4 h-4" />
-      </button>
     </label>
   )
 );

--- a/src/features/visit/ComplaintSelector/components/NewComplaintInput.tsx
+++ b/src/features/visit/ComplaintSelector/components/NewComplaintInput.tsx
@@ -9,15 +9,36 @@ interface NewComplaintInputProps {
   onFocus: () => void;
   onBlur: () => void;
   onClick?: () => void;
+
+  // ARIA attributes lifted for accessibility (C3). We chose optional props with safe fallback values
+  // to maintain backward compatibility in tests and prevent breaking other component consumers.
+  inputId?: string;
+  listboxId?: string;
+  popoverOpen?: boolean;
+  focusedIndex?: number;
 }
 
 // forwardRef so the parent can pass anchorRef to this element —
 // the CatalogSearchPopover uses it to calculate its position.
 export const NewComplaintInput = forwardRef<HTMLLabelElement, NewComplaintInputProps>(
-  ({ value, onChange, onKeyDown, onFocus, onBlur, onClick }, ref) => (
+  (
+    {
+      value,
+      onChange,
+      onKeyDown,
+      onFocus,
+      onBlur,
+      onClick,
+      inputId = "new_complaint",
+      listboxId,
+      popoverOpen = false,
+      focusedIndex = 0,
+    },
+    ref
+  ) => (
     <label
       ref={ref}
-      htmlFor="new_complaint"
+      htmlFor={inputId}
       className={cn(
         "flex items-center px-4 py-3 rounded-lg border-2 border-dashed cursor-text",
         "border-zinc-300 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/30",
@@ -30,7 +51,7 @@ export const NewComplaintInput = forwardRef<HTMLLabelElement, NewComplaintInputP
       {/* Use SearchIcon instead of PlusIcon to signal "search catalog" intent */}
       <SearchIcon className="w-5 h-5 text-zinc-400 dark:text-zinc-500 mr-4 shrink-0" />
       <input
-        id="new_complaint"
+        id={inputId}
         type="text"
         value={value}
         onChange={(e) => onChange(e.currentTarget.value)}
@@ -42,6 +63,18 @@ export const NewComplaintInput = forwardRef<HTMLLabelElement, NewComplaintInputP
         // click-outside detector handles that correctly.
         onBlur={onBlur}
         placeholder="Search complaints..."
+        // C3 ARIA Attributes:
+        // We bind role="combobox" and dynamic attributes via standard React props rather than imperative DOM mutation.
+        // This ensures they stay in sync with the virtual DOM and are not overwritten during React reconciliation.
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={popoverOpen}
+        aria-controls={popoverOpen && listboxId ? listboxId : undefined}
+        aria-activedescendant={
+          popoverOpen && listboxId && focusedIndex >= 0
+            ? `${listboxId}-option-${focusedIndex}`
+            : undefined
+        }
         className="flex-1 bg-transparent border-none outline-none text-zinc-900 dark:text-white placeholder-zinc-400 dark:placeholder-zinc-600 font-medium text-sm"
       />
     </label>

--- a/src/features/visit/ComplaintSelector/hook/useComplaintSelection.tsx
+++ b/src/features/visit/ComplaintSelector/hook/useComplaintSelection.tsx
@@ -38,6 +38,12 @@ export function useComplaintSelection(available: MedicalComplaint[]) {
 
   const remove = (i: string) => {
     setCustomComplaints(c => c.filter(c => c.id !== i))
+    setSelectedIds(prev => {
+      if (!prev.has(i)) return prev;
+      const next = new Set(prev);
+      next.delete(i);
+      return next;
+    });
   }
 
   return {

--- a/src/features/visit/ComplaintSelector/hook/useComplaintSelection.tsx
+++ b/src/features/visit/ComplaintSelector/hook/useComplaintSelection.tsx
@@ -36,15 +36,17 @@ export function useComplaintSelection(available: MedicalComplaint[]) {
     setCustomComplaints([]);
   };
 
-  const remove = (i: string) => {
-    setCustomComplaints(c => c.filter(c => c.id !== i))
+  const remove = (id: string) => {
+    // Avoid variable shadowing: using distinct names for the state array (prev) and the mapped elements (item)
+    // to prevent lexical scope collision and satisfy the TS compiler/linter.
+    setCustomComplaints(prev => prev.filter(item => item.id !== id));
     setSelectedIds(prev => {
-      if (!prev.has(i)) return prev;
+      if (!prev.has(id)) return prev;
       const next = new Set(prev);
-      next.delete(i);
+      next.delete(id);
       return next;
     });
-  }
+  };
 
   return {
     allComplaints,

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -1,90 +1,195 @@
-import { useState } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import type { MedicalComplaint, Patient } from "@/types";
 import { PatientHeader } from "./components/PatientHeader";
 import { SectionLabel } from "./components/primitives";
 import { NewComplaintInput } from "./components/NewComplaintInput";
 import { FooterActions } from "./components/FooterActions";
 import { ComplaintItem } from "./components/ComplaintItem";
+import { CatalogSearchPopover } from "./components/CatalogSearchPopover";
+import { COMPLAINT_CATALOG } from "@/data/complaints_catalog";
 import { formatBracketText } from "@/lib";
 import { useComplaintSelection } from "./hook/useComplaintSelection";
 
 interface ComplaintSelectorProps {
-    patient: Patient;
-    availableComplaints: MedicalComplaint[];
-    onConfirm: (selectedIds: string[]) => void;
-    onCancel: () => void;
+  patient: Patient;
+  // These are the patient's existing ACTIVE complaints — the checklist.
+  availableComplaints: MedicalComplaint[];
+  onConfirm: (selectedIds: string[]) => void;
+  onCancel: () => void;
 }
 
 export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
-    patient,
-    availableComplaints,
-    onConfirm,
-    onCancel,
+  patient,
+  availableComplaints,
+  onConfirm,
+  onCancel,
 }) => {
-    const { add, remove, allComplaints, reset, selectedIds, toggle } = useComplaintSelection(availableComplaints)
-    const [newComplaintInput, setNewComplaintInput] = useState("");
+  const { add, remove, allComplaints, reset, selectedIds, toggle } =
+    useComplaintSelection(availableComplaints);
 
-    const handleCancel = () => {
-        reset()
-        setNewComplaintInput("");
-        onCancel();
-    };
+  // ── "Add new complaint" input state ────────────────────────────────────────
+  const [newComplaintInput, setNewComplaintInput] = useState("");
+  // Controls popover visibility; opened on focus, closed by click-outside/Escape.
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  // Ref is forwarded to the NewComplaintInput label element — the popover uses
+  // it to measure position and detect click-outside correctly.
+  const inputRef = useRef<HTMLLabelElement>(null);
 
-    const handleConfirm = () => {
-        onConfirm(Array.from(selectedIds));
-    };
+  // Ref to the scrollable checklist container to programmatically adjust scroll position.
+  // Choosing container.scrollTo over element.scrollIntoView to avoid layout jitter and keep scrolling contained strictly within the panel.
+  const listContainerRef = useRef<HTMLDivElement>(null);
 
-    const handleAddNewComplaint = () => {
-        const trimmedInput = newComplaintInput.trim();
-        const formatted = formatBracketText(trimmedInput)
-        if (!formatted) return;
+  // Tracks the previous count of complaints to identify when a new item is added.
+  const prevCountRef = useRef(allComplaints.length);
 
-        add(formatted)
-        setNewComplaintInput("");
+  // Scroll to the bottom of the list when a new complaint item is appended.
+  // We check if the current count is greater than the previous count to avoid scrolling on deletion or initial mount.
+  // We use a small setTimeout delay to allow the browser to complete layout calculations and paint the new item,
+  // ensuring listContainerRef.current.scrollHeight is up-to-date and the item is fully visible.
+  useEffect(() => {
+    if (allComplaints.length > prevCountRef.current) {
+      if (listContainerRef.current) {
+        const container = listContainerRef.current;
+        const timer = setTimeout(() => {
+          container.scrollTo({
+            top: container.scrollHeight,
+            behavior: "smooth",
+          });
+        }, 50);
+        return () => clearTimeout(timer);
+      }
+    }
+    prevCountRef.current = allComplaints.length;
+  }, [allComplaints.length]);
 
-    };
+  // ── Handlers ───────────────────────────────────────────────────────────────
+  const handleCancel = () => {
+    reset();
+    setNewComplaintInput("");
+    setPopoverOpen(false);
+    onCancel();
+  };
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "Enter") {
-            e.preventDefault();
-            handleAddNewComplaint();
-        }
-    };
+  const handleConfirm = () => {
+    onConfirm(Array.from(selectedIds));
+  };
 
-    return (
-        <div className="w-full max-h-[90dvh] flex flex-col max-w-2xl bg-white dark:bg-black border border-zinc-200 dark:border-zinc-800 rounded-xl p-8 shadow-2xl transition-colors duration-300">
-            <PatientHeader patient={patient} />
+  // Typing a completely free-form complaint and pressing Enter/clicking +
+  const handleAddFreeText = () => {
+    const trimmed = newComplaintInput.trim();
+    const formatted = formatBracketText(trimmed);
+    if (!formatted) return;
+    add(formatted);
+    setNewComplaintInput("");
+    // Close the suggestions popover once an item has been successfully added.
+    // This satisfies the requirement to dismiss suggestions immediately upon addition.
+    setPopoverOpen(false);
+  };
 
-            <div className="mb-6 flex-1 min-h-0">
-                <SectionLabel text="Select Visit Complaint (Multiple Selection Allowed)" />
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddFreeText();
+    }
+    if (e.key === "Escape") {
+      setPopoverOpen(false);
+    }
+  };
 
-                <div className="h-full  space-y-3 overflow-y-auto pr-3">
-                    {allComplaints.map((complaint) => (
-                        <ComplaintItem
-                            key={complaint.id}
-                            complaint={complaint}
-                            isSelected={selectedIds.has(complaint.id)}
-                            onToggle={toggle}
-                            remove={remove}
-                        />
-                    ))}
+  // Picking an item from the catalog popover — we treat it like a free-text add
+  // but using the catalog item's title, then mark it auto-selected.
+  const handleCatalogSelect = useCallback(
+    (item: MedicalComplaint) => {
+      add(item.title);
+      // Clear the query so the popover returns to the default "all" view,
+      // ready for a possible second addition without visual clutter.
+      setNewComplaintInput("");
+      // Close the suggestions popover when an item is selected from the suggestions catalog list.
+      setPopoverOpen(false);
+    },
+    [add]
+  );
 
-                    <NewComplaintInput
-                        value={newComplaintInput}
-                        onChange={setNewComplaintInput}
-                        onKeyDown={handleKeyDown}
-                        onAdd={handleAddNewComplaint}
-                    />
-                </div>
-            </div>
+  // Grey-out catalog entries whose titles are already in the active list.
+  // We match by lowercased title since catalog IDs differ from complaint IDs
+  // produced by useComplaintSelection. O(n*m) but both sets are tiny (<60 items).
+  const existingTitlesLower = new Set(allComplaints.map((c) => c.title.toLowerCase()));
+  const catalogExistingIds = new Set(
+    COMPLAINT_CATALOG
+      .filter((c) => existingTitlesLower.has(c.title.toLowerCase()))
+      .map((c) => c.id)
+  );
 
-            <FooterActions
-                onCancel={handleCancel}
-                onConfirm={handleConfirm}
-                isConfirmDisabled={selectedIds.size === 0}
+  return (
+    <div className="w-full max-h-[90dvh] flex flex-col max-w-2xl bg-white dark:bg-black border border-zinc-200 dark:border-zinc-800 rounded-xl p-8 shadow-2xl transition-colors duration-300">
+      <PatientHeader patient={patient} />
+
+      {/* ── Active complaints checklist ─────────────────────────────────────── */}
+      {/* This is the PRIMARY workflow: the doctor checks off what they are treating
+          today from the patient's existing active complaints. */}
+      <div className="mb-4 flex-1 min-h-0 flex flex-col">
+        <SectionLabel text="Select Visit Complaints (Multiple Allowed)" />
+
+        {/* Scrollable checklist — flex-1 so it fills available space */}
+        <div
+          ref={listContainerRef}
+          className="flex-1 min-h-0 space-y-3 overflow-y-auto pr-3 pb-3"
+        >
+          {allComplaints.map((complaint) => (
+            <ComplaintItem
+              key={complaint.id}
+              complaint={complaint}
+              isSelected={selectedIds.has(complaint.id)}
+              onToggle={toggle}
+              remove={remove}
             />
+          ))}
         </div>
-    );
+
+        {/* ── Add New Complaint — sits BELOW the scroll area, always visible ──
+             Moved out of the scrollable div intentionally: it acts as a sticky
+             gateway and should never scroll out of view. */}
+        <div className="mt-3">
+          <NewComplaintInput
+            ref={inputRef}
+            value={newComplaintInput}
+            onChange={(val) => {
+              setNewComplaintInput(val);
+              // Re-open suggestions popover if the user types or modifies text
+              setPopoverOpen(true);
+            }}
+            onKeyDown={handleKeyDown}
+            onAdd={handleAddFreeText}
+            onFocus={() => setPopoverOpen(true)}
+            onClick={() => {
+              // Re-open suggestions popover on clicking the focused input text box itself,
+              // bypassing the limitation where focus events do not re-trigger on already focused elements.
+              setPopoverOpen(true);
+            }}
+            onBlur={() => {/* intentionally empty — popover handles close */ }}
+          />
+        </div>
+      </div>
+
+      <FooterActions
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+        isConfirmDisabled={selectedIds.size === 0}
+      />
+
+      {/* ── Catalog search popover (portal) ─────────────────────────────────
+           Rendered at document.body level to escape overflow:hidden / max-h
+           constraints of any ancestor. */}
+      <CatalogSearchPopover
+        anchorRef={inputRef}
+        query={newComplaintInput}
+        isOpen={popoverOpen}
+        onSelect={handleCatalogSelect}
+        onClose={() => setPopoverOpen(false)}
+        existingIds={catalogExistingIds}
+      />
+    </div>
+  );
 };
 
 export default ComplaintSelector;

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useId, useMemo } from "react";
+import { useState, useRef, useCallback, useEffect, useId } from "react";
 import type { MedicalComplaint, Patient } from "@/types";
 import { PatientHeader } from "./components/PatientHeader";
 import { SectionLabel } from "./components/primitives";
@@ -40,15 +40,15 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
   // it to measure position and detect click-outside correctly.
   const inputRef = useRef<HTMLLabelElement>(null);
 
-  // C3: State for tracking currently focused item in the search results popover.
+  // State for tracking currently focused item in the search results popover.
   // Lifted from the popover component to handle arrow keys cleanly via React event handling.
   const [focusedIndex, setFocusedIndex] = useState(0);
 
-  // C3: State to keep track of the currently filtered catalog items array.
+  // State to keep track of the currently filtered catalog items array.
   // Received from CatalogSearchPopover to clamp keyboard focus limits and handle selection.
   const [filteredCatalogItems, setFilteredCatalogItems] = useState<MedicalComplaint[]>([]);
 
-  // C3: State for the selected region filter chip. Lifted up to index.tsx to allow
+  // State for the selected region filter chip. Lifted up to index.tsx to allow
   // unified keyboard navigation (ctrl + ArrowLeft/Right) inside the input's handleKeyDown.
   const [selectedRegion, setSelectedRegion] = useState<CatalogRegion>("All");
 
@@ -56,17 +56,27 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
   // Choosing container.scrollTo over element.scrollIntoView to avoid layout jitter and keep scrolling contained strictly within the panel.
   const listContainerRef = useRef<HTMLDivElement>(null);
 
-  // Tracks the previous count of complaints to identify when a new item is added.
-  const complaintsCountRef = useRef(allComplaints.length);
+  // Derive state: reset focus index if filtered results change while popover is open.
+  // This prevents staleness where focusedIndex points to the wrong item after list content changes.
+  // Doing this during render avoids the react-hooks/set-state-in-effect warning.
+  const [prevFilteredCatalogItems, setPrevFilteredCatalogItems] = useState(filteredCatalogItems);
+  if (filteredCatalogItems !== prevFilteredCatalogItems) {
+    setPrevFilteredCatalogItems(filteredCatalogItems);
+    if (popoverOpen) {
+      setFocusedIndex(0);
+    }
+  }
+
+  // Tracks the previous count of complaints to identify when a new item is added for scrolling.
+  const complaintsScrollRef = useRef(allComplaints.length);
 
   // Scroll to the bottom of the list when a new complaint item is appended.
   // We check if the current count is greater than the previous count to avoid scrolling on deletion or initial mount.
   // We use a small setTimeout delay to allow the browser to complete layout calculations and paint the new item,
   // ensuring listContainerRef.current.scrollHeight is up-to-date and the item is fully visible.
   useEffect(() => {
-    const prevCount = complaintsCountRef.current;
-    complaintsCountRef.current = allComplaints.length;
-
+    const prevCount = complaintsScrollRef.current;
+    complaintsScrollRef.current = allComplaints.length;
     if (allComplaints.length > prevCount && listContainerRef.current) {
       const container = listContainerRef.current;
       const timer = setTimeout(() => {
@@ -79,18 +89,8 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     }
   }, [allComplaints.length]);
 
-  // C3: Reset focused index to the first element (0) by default whenever the search results change.
-  // This satisfies the requirement to have default focus on the first search result.
-  useEffect(() => {
-    setFocusedIndex(0);
-  }, [filteredCatalogItems]);
-
-  // C3: Reset focused index to the first element when the popover closes.
-  useEffect(() => {
-    if (!popoverOpen) {
-      setFocusedIndex(0);
-    }
-  }, [popoverOpen]);
+  // Note: Resetting of focusedIndex is now handled inline inside event handlers (onChange, onRegionChange, handleKeyDown, onClose)
+  // and in the filteredCatalogItems derived state above to avoid cascading renders while maintaining full coverage.
 
   // ── Handlers ───────────────────────────────────────────────────────────────
   const handleCancel = () => {
@@ -98,21 +98,24 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     setNewComplaintInput("");
     setPopoverOpen(false);
     onCancel();
-    // C3: Reset keyboard focus index on cancel
+    // Reset keyboard focus index on cancel
     setFocusedIndex(0);
     setSelectedRegion("All"); // Reset region chip filter on cancel
   };
 
   // Stable onClose callback to prevent the child component's click-outside event listener 
   // from repeatedly tearing down and rebuilding on every render.
-  const handlePopoverClose = useCallback(() => setPopoverOpen(false), []);
+  const handlePopoverClose = useCallback(() => {
+    setPopoverOpen(false);
+    setFocusedIndex(0);
+  }, []);
 
   const handleConfirm = () => {
     onConfirm(Array.from(selectedIds));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    // C3: Key navigation listener for search results.
+    // Key navigation listener for search results.
     // ArrowDown, ArrowUp, Enter, and Ctrl+ArrowRight/Left keys are intercepted when the popover is open.
     if (popoverOpen) {
       // ctrl + ArrowRight/Left triggers region chip change
@@ -121,6 +124,7 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
         const currentIndex = CATALOG_REGIONS.indexOf(selectedRegion);
         const nextIndex = (currentIndex + 1) % CATALOG_REGIONS.length;
         setSelectedRegion(CATALOG_REGIONS[nextIndex]);
+        setFocusedIndex(0);
         return;
       }
       if (e.ctrlKey && e.key === "ArrowLeft") {
@@ -128,36 +132,37 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
         const currentIndex = CATALOG_REGIONS.indexOf(selectedRegion);
         const nextIndex = (currentIndex - 1 + CATALOG_REGIONS.length) % CATALOG_REGIONS.length;
         setSelectedRegion(CATALOG_REGIONS[nextIndex]);
+        setFocusedIndex(0);
         return;
       }
 
       if (filteredCatalogItems.length > 0) {
+        const safeIndex = Math.max(0, Math.min(focusedIndex, filteredCatalogItems.length - 1));
+
         if (e.key === "ArrowDown") {
           e.preventDefault();
           // Clamp focus to the last element of the list
-          setFocusedIndex((prev) => Math.min(prev + 1, filteredCatalogItems.length - 1));
+          setFocusedIndex(Math.min(safeIndex + 1, filteredCatalogItems.length - 1));
           return;
         }
         if (e.key === "ArrowUp") {
           e.preventDefault();
           // Clamp focus to the first element of the list
-          setFocusedIndex((prev) => Math.max(prev - 1, 0));
+          setFocusedIndex(Math.max(safeIndex - 1, 0));
           return;
         }
         if (e.key === "Enter") {
           // Intercept enter press to select highlighted catalog suggestion item
-          if (focusedIndex >= 0 && focusedIndex < filteredCatalogItems.length) {
-            const item = filteredCatalogItems[focusedIndex];
-            const alreadyAdded = catalogExistingIds.has(item.id);
-            if (!alreadyAdded) {
-              e.preventDefault();
-              handleCatalogSelect(item);
-              return;
-            } else {
-              // Block adding disabled suggestion as custom text
-              e.preventDefault();
-              return;
-            }
+          const item = filteredCatalogItems[safeIndex];
+          const alreadyAdded = catalogExistingIds.has(item.id);
+          if (!alreadyAdded) {
+            e.preventDefault();
+            handleCatalogSelect(item);
+            return;
+          } else {
+            // Block adding disabled suggestion as custom text
+            e.preventDefault();
+            return;
           }
         }
       }
@@ -166,6 +171,7 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     if (e.key === "Escape") {
       setPopoverOpen(false);
       setSelectedRegion("All"); // Reset region chip to All on escape
+      setFocusedIndex(0);
     }
   };
 
@@ -182,7 +188,7 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     // We intentionally keep the popover open on item selection to support multiple selections in a row.
     // This is a trade-off where the user has to close the popover explicitly (e.g. click outside, Escape, Cancel),
     // but it speeds up multi-selection workflows significantly.
-    // C3: Reset keyboard focus index on selection
+    // Reset keyboard focus index on selection
     setFocusedIndex(0);
   }
 
@@ -191,14 +197,16 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
   // produced by useComplaintSelection. O(n*m) but both sets are tiny (<60 items).
   // TODO: [Backend Integration] When a backend API is added, store the catalog ID on the
   // active complaint schema. This will allow matching by stable ID instead of title strings.
-  const catalogExistingIds = useMemo(() => {
-    const existingTitlesLower = new Set(allComplaints.map((c) => c.title.toLowerCase()))
-    return new Set(
-      COMPLAINT_CATALOG
-        .filter((c) => existingTitlesLower.has(c.title.toLowerCase()))
-        .map((c) => c.id)
-    )
-  }, [allComplaints]);
+  const existingTitlesLower = new Set(allComplaints.map((c) => c.title.toLowerCase()));
+  const catalogExistingIds = new Set(
+    COMPLAINT_CATALOG
+      .filter((c) => existingTitlesLower.has(c.title.toLowerCase()))
+      .map((c) => c.id)
+  );
+
+  // Compute a structurally safe index that can never be out of bounds, 
+  // regardless of how or why the list length changes.
+  const safeFocusedIndex = Math.max(0, Math.min(focusedIndex, Math.max(0, filteredCatalogItems.length - 1)));
 
   return (
     <div className="w-full max-h-[90dvh] flex flex-col max-w-2xl bg-white dark:bg-black border border-zinc-200 dark:border-zinc-800 rounded-xl p-8 shadow-2xl transition-colors duration-300">
@@ -237,6 +245,7 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
               setNewComplaintInput(val);
               // Re-open suggestions popover if the user types or modifies text
               setPopoverOpen(true);
+              setFocusedIndex(0);
             }}
             onKeyDown={handleKeyDown}
             onFocus={() => setPopoverOpen(true)}
@@ -250,7 +259,7 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
             inputId={inputId}
             listboxId={listboxId}
             popoverOpen={popoverOpen}
-            focusedIndex={focusedIndex}
+            focusedIndex={safeFocusedIndex}
           />
         </div>
       </div>
@@ -272,12 +281,15 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
         onClose={handlePopoverClose}
         existingIds={catalogExistingIds}
         // Pass down state and callback props to keep popover in sync with lifted navigation state
-        focusedIndex={focusedIndex}
+        focusedIndex={safeFocusedIndex}
         listboxId={listboxId}
         onFilteredItemsChange={setFilteredCatalogItems}
         // Pass down lifted region state and setter callback
         selectedRegion={selectedRegion}
-        onRegionChange={setSelectedRegion}
+        onRegionChange={(region) => {
+          setSelectedRegion(region);
+          setFocusedIndex(0);
+        }}
       />
     </div>
   );

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import type { MedicalComplaint, Patient } from "@/types";
 import { PatientHeader } from "./components/PatientHeader";
 import { SectionLabel } from "./components/primitives";
@@ -102,6 +102,10 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     setSelectedRegion("All"); // Reset region chip filter on cancel
   };
 
+  // Stable onClose callback to prevent the child component's click-outside event listener 
+  // from repeatedly tearing down and rebuilding on every render.
+  const handlePopoverClose = useCallback(() => setPopoverOpen(false), []);
+
   const handleConfirm = () => {
     onConfirm(Array.from(selectedIds));
   };
@@ -161,35 +165,39 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     if (e.key === "Escape") {
       setPopoverOpen(false);
       setSelectedRegion("All"); // Reset region chip to All on escape
-      }
+    }
   };
 
   // Picking an item from the catalog popover — we treat it like a free-text add
   // but using the catalog item's title, then mark it auto-selected.
-  const handleCatalogSelect = useCallback(
-    (item: MedicalComplaint) => {
-      add(item.title);
-      // Clear the query so the popover returns to the default "all" view,
-      // ready for a possible second addition without visual clutter.
-      setNewComplaintInput("");
-      // We intentionally keep the popover open on item selection to support multiple selections in a row.
-      // This is a trade-off where the user has to close the popover explicitly (e.g. click outside, Escape, Cancel),
-      // but it speeds up multi-selection workflows significantly.
-      // C3: Reset keyboard focus index on selection
-      setFocusedIndex(0);
-    },
-    [add]
-  );
+  // TODO: Future optimization (Option 2): If catalog search results performance degrades,
+  // we can wrap this in a useCallback (requires wrapping the custom hook's `add` in useCallback first)
+  // and wrap CatalogSearchPopover in React.memo to prevent unnecessary re-renders.
+  const handleCatalogSelect = (item: MedicalComplaint) => {
+    add(item.title);
+    // Clear the query so the popover returns to the default "all" view,
+    // ready for a possible second addition without visual clutter.
+    setNewComplaintInput("");
+    // We intentionally keep the popover open on item selection to support multiple selections in a row.
+    // This is a trade-off where the user has to close the popover explicitly (e.g. click outside, Escape, Cancel),
+    // but it speeds up multi-selection workflows significantly.
+    // C3: Reset keyboard focus index on selection
+    setFocusedIndex(0);
+  }
 
   // Grey-out catalog entries whose titles are already in the active list.
   // We match by lowercased title since catalog IDs differ from complaint IDs
   // produced by useComplaintSelection. O(n*m) but both sets are tiny (<60 items).
-  const existingTitlesLower = new Set(allComplaints.map((c) => c.title.toLowerCase()));
-  const catalogExistingIds = new Set(
-    COMPLAINT_CATALOG
-      .filter((c) => existingTitlesLower.has(c.title.toLowerCase()))
-      .map((c) => c.id)
-  );
+  // TODO: [Backend Integration] When a backend API is added, store the catalog ID on the
+  // active complaint schema. This will allow matching by stable ID instead of title strings.
+  const catalogExistingIds = useMemo(() => {
+    const existingTitlesLower = new Set(allComplaints.map((c) => c.title.toLowerCase()))
+    return new Set(
+      COMPLAINT_CATALOG
+        .filter((c) => existingTitlesLower.has(c.title.toLowerCase()))
+        .map((c) => c.id)
+    )
+  }, [allComplaints]);
 
   return (
     <div className="w-full max-h-[90dvh] flex flex-col max-w-2xl bg-white dark:bg-black border border-zinc-200 dark:border-zinc-800 rounded-xl p-8 shadow-2xl transition-colors duration-300">
@@ -260,7 +268,7 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
         query={newComplaintInput}
         isOpen={popoverOpen}
         onSelect={handleCatalogSelect}
-        onClose={() => setPopoverOpen(false)}
+        onClose={handlePopoverClose}
         existingIds={catalogExistingIds}
         // C3: Pass down state and callback props to keep popover in sync with lifted navigation state
         focusedIndex={focusedIndex}

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -6,9 +6,13 @@ import { NewComplaintInput } from "./components/NewComplaintInput";
 import { FooterActions } from "./components/FooterActions";
 import { ComplaintItem } from "./components/ComplaintItem";
 import { CatalogSearchPopover } from "./components/CatalogSearchPopover";
-import { COMPLAINT_CATALOG } from "@/data/complaints_catalog";
-
+import { COMPLAINT_CATALOG, CATALOG_REGIONS, type CatalogRegion } from "@/data/complaints_catalog";
 import { useComplaintSelection } from "./hook/useComplaintSelection";
+
+// C3: Dynamic ARIA control IDs. We declare them as constants to link the combobox input
+// with its option listbox elements correctly for accessibility.
+const INPUT_ID = "new_complaint_input";
+const LISTBOX_ID = "new_complaint_listbox";
 
 interface ComplaintSelectorProps {
   patient: Patient;
@@ -34,6 +38,18 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
   // Ref is forwarded to the NewComplaintInput label element — the popover uses
   // it to measure position and detect click-outside correctly.
   const inputRef = useRef<HTMLLabelElement>(null);
+
+  // C3: State for tracking currently focused item in the search results popover.
+  // Lifted from the popover component to handle arrow keys cleanly via React event handling.
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  // C3: State to keep track of the currently filtered catalog items array.
+  // Received from CatalogSearchPopover to clamp keyboard focus limits and handle selection.
+  const [filteredCatalogItems, setFilteredCatalogItems] = useState<MedicalComplaint[]>([]);
+
+  // C3: State for the selected region filter chip. Lifted up to index.tsx to allow
+  // unified keyboard navigation (ctrl + ArrowLeft/Right) inside the input's handleKeyDown.
+  const [selectedRegion, setSelectedRegion] = useState<CatalogRegion>("All");
 
   // Ref to the scrollable checklist container to programmatically adjust scroll position.
   // Choosing container.scrollTo over element.scrollIntoView to avoid layout jitter and keep scrolling contained strictly within the panel.
@@ -62,25 +78,90 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     prevCountRef.current = allComplaints.length;
   }, [allComplaints.length]);
 
+  // C3: Reset focused index to the first element (0) by default whenever the search results change.
+  // This satisfies the requirement to have default focus on the first search result.
+  useEffect(() => {
+    setFocusedIndex(0);
+  }, [filteredCatalogItems]);
+
+  // C3: Reset focused index to the first element when the popover closes.
+  useEffect(() => {
+    if (!popoverOpen) {
+      setFocusedIndex(0);
+    }
+  }, [popoverOpen]);
+
   // ── Handlers ───────────────────────────────────────────────────────────────
   const handleCancel = () => {
     reset();
     setNewComplaintInput("");
     setPopoverOpen(false);
     onCancel();
+    // C3: Reset keyboard focus index on cancel
+    setFocusedIndex(0);
+    setSelectedRegion("All"); // Reset region chip filter on cancel
   };
 
   const handleConfirm = () => {
     onConfirm(Array.from(selectedIds));
   };
 
-  // handleKeyDown handles keyboard events. We removed the Enter key handler for free-text addition
-  // since custom/free-text complaints are no longer allowed. Keyboard navigation (up/down arrow/Enter selection)
-  // will be implemented here later.
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // C3: Key navigation listener for search results.
+    // ArrowDown, ArrowUp, Enter, and Ctrl+ArrowRight/Left keys are intercepted when the popover is open.
+    if (popoverOpen) {
+      // ctrl + ArrowRight/Left triggers region chip change
+      if (e.ctrlKey && e.key === "ArrowRight") {
+        e.preventDefault();
+        const currentIndex = CATALOG_REGIONS.indexOf(selectedRegion);
+        const nextIndex = (currentIndex + 1) % CATALOG_REGIONS.length;
+        setSelectedRegion(CATALOG_REGIONS[nextIndex]);
+        return;
+      }
+      if (e.ctrlKey && e.key === "ArrowLeft") {
+        e.preventDefault();
+        const currentIndex = CATALOG_REGIONS.indexOf(selectedRegion);
+        const nextIndex = (currentIndex - 1 + CATALOG_REGIONS.length) % CATALOG_REGIONS.length;
+        setSelectedRegion(CATALOG_REGIONS[nextIndex]);
+        return;
+      }
+
+      if (filteredCatalogItems.length > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          // Clamp focus to the last element of the list
+          setFocusedIndex((prev) => Math.min(prev + 1, filteredCatalogItems.length - 1));
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          // Clamp focus to the first element of the list
+          setFocusedIndex((prev) => Math.max(prev - 1, 0));
+          return;
+        }
+        if (e.key === "Enter") {
+          // Intercept enter press to select highlighted catalog suggestion item
+          if (focusedIndex >= 0 && focusedIndex < filteredCatalogItems.length) {
+            const item = filteredCatalogItems[focusedIndex];
+            const alreadyAdded = catalogExistingIds.has(item.id);
+            if (!alreadyAdded) {
+              e.preventDefault();
+              handleCatalogSelect(item);
+              return;
+            } else {
+              // Block adding disabled suggestion as custom text
+              e.preventDefault();
+              return;
+            }
+          }
+        }
+      }
+    }
+
     if (e.key === "Escape") {
       setPopoverOpen(false);
-    }
+      setSelectedRegion("All"); // Reset region chip to All on escape
+      }
   };
 
   // Picking an item from the catalog popover — we treat it like a free-text add
@@ -91,8 +172,11 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
       // Clear the query so the popover returns to the default "all" view,
       // ready for a possible second addition without visual clutter.
       setNewComplaintInput("");
-      // Close the suggestions popover when an item is selected from the suggestions catalog list.
-      setPopoverOpen(false);
+      // We intentionally keep the popover open on item selection to support multiple selections in a row.
+      // This is a trade-off where the user has to close the popover explicitly (e.g. click outside, Escape, Cancel),
+      // but it speeds up multi-selection workflows significantly.
+      // C3: Reset keyboard focus index on selection
+      setFocusedIndex(0);
     },
     [add]
   );
@@ -153,6 +237,11 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
               setPopoverOpen(true);
             }}
             onBlur={() => {/* intentionally empty — popover handles close */ }}
+            // C3: Pass down ARIA properties to bind them directly on the input element
+            inputId={INPUT_ID}
+            listboxId={LISTBOX_ID}
+            popoverOpen={popoverOpen}
+            focusedIndex={focusedIndex}
           />
         </div>
       </div>
@@ -173,6 +262,13 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
         onSelect={handleCatalogSelect}
         onClose={() => setPopoverOpen(false)}
         existingIds={catalogExistingIds}
+        // C3: Pass down state and callback props to keep popover in sync with lifted navigation state
+        focusedIndex={focusedIndex}
+        listboxId={LISTBOX_ID}
+        onFilteredItemsChange={setFilteredCatalogItems}
+        // C3: Pass down lifted region state and setter callback
+        selectedRegion={selectedRegion}
+        onRegionChange={setSelectedRegion}
       />
     </div>
   );

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -56,26 +56,26 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
   const listContainerRef = useRef<HTMLDivElement>(null);
 
   // Tracks the previous count of complaints to identify when a new item is added.
-  const prevCountRef = useRef(allComplaints.length);
+  const complaintsCountRef = useRef(allComplaints.length);
 
   // Scroll to the bottom of the list when a new complaint item is appended.
   // We check if the current count is greater than the previous count to avoid scrolling on deletion or initial mount.
   // We use a small setTimeout delay to allow the browser to complete layout calculations and paint the new item,
   // ensuring listContainerRef.current.scrollHeight is up-to-date and the item is fully visible.
   useEffect(() => {
-    if (allComplaints.length > prevCountRef.current) {
-      if (listContainerRef.current) {
-        const container = listContainerRef.current;
-        const timer = setTimeout(() => {
-          container.scrollTo({
-            top: container.scrollHeight,
-            behavior: "smooth",
-          });
-        }, 50);
-        return () => clearTimeout(timer);
-      }
+    const prevCount = complaintsCountRef.current;
+    complaintsCountRef.current = allComplaints.length;
+
+    if (allComplaints.length > prevCount && listContainerRef.current) {
+      const container = listContainerRef.current;
+      const timer = setTimeout(() => {
+        container.scrollTo({
+          top: container.scrollHeight,
+          behavior: "smooth",
+        });
+      }, 50);
+      return () => clearTimeout(timer);
     }
-    prevCountRef.current = allComplaints.length;
   }, [allComplaints.length]);
 
   // C3: Reset focused index to the first element (0) by default whenever the search results change.

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -7,7 +7,7 @@ import { FooterActions } from "./components/FooterActions";
 import { ComplaintItem } from "./components/ComplaintItem";
 import { CatalogSearchPopover } from "./components/CatalogSearchPopover";
 import { COMPLAINT_CATALOG } from "@/data/complaints_catalog";
-import { formatBracketText } from "@/lib";
+
 import { useComplaintSelection } from "./hook/useComplaintSelection";
 
 interface ComplaintSelectorProps {
@@ -74,23 +74,10 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
     onConfirm(Array.from(selectedIds));
   };
 
-  // Typing a completely free-form complaint and pressing Enter/clicking +
-  const handleAddFreeText = () => {
-    const trimmed = newComplaintInput.trim();
-    const formatted = formatBracketText(trimmed);
-    if (!formatted) return;
-    add(formatted);
-    setNewComplaintInput("");
-    // Close the suggestions popover once an item has been successfully added.
-    // This satisfies the requirement to dismiss suggestions immediately upon addition.
-    setPopoverOpen(false);
-  };
-
+  // handleKeyDown handles keyboard events. We removed the Enter key handler for free-text addition
+  // since custom/free-text complaints are no longer allowed. Keyboard navigation (up/down arrow/Enter selection)
+  // will be implemented here later.
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleAddFreeText();
-    }
     if (e.key === "Escape") {
       setPopoverOpen(false);
     }
@@ -159,7 +146,6 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
               setPopoverOpen(true);
             }}
             onKeyDown={handleKeyDown}
-            onAdd={handleAddFreeText}
             onFocus={() => setPopoverOpen(true)}
             onClick={() => {
               // Re-open suggestions popover on clicking the focused input text box itself,

--- a/src/features/visit/ComplaintSelector/index.tsx
+++ b/src/features/visit/ComplaintSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import { useState, useRef, useCallback, useEffect, useId, useMemo } from "react";
 import type { MedicalComplaint, Patient } from "@/types";
 import { PatientHeader } from "./components/PatientHeader";
 import { SectionLabel } from "./components/primitives";
@@ -8,11 +8,6 @@ import { ComplaintItem } from "./components/ComplaintItem";
 import { CatalogSearchPopover } from "./components/CatalogSearchPopover";
 import { COMPLAINT_CATALOG, CATALOG_REGIONS, type CatalogRegion } from "@/data/complaints_catalog";
 import { useComplaintSelection } from "./hook/useComplaintSelection";
-
-// C3: Dynamic ARIA control IDs. We declare them as constants to link the combobox input
-// with its option listbox elements correctly for accessibility.
-const INPUT_ID = "new_complaint_input";
-const LISTBOX_ID = "new_complaint_listbox";
 
 interface ComplaintSelectorProps {
   patient: Patient;
@@ -30,6 +25,12 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
 }) => {
   const { add, remove, allComplaints, reset, selectedIds, toggle } =
     useComplaintSelection(availableComplaints);
+
+  // Generate dynamic, unique IDs to link the search input with its popover listbox
+  // for accessibility. This guarantees DOM ID uniqueness even if multiple selectors are on the page.
+  const uniqueId = useId();
+  const inputId = `${uniqueId}-input`;
+  const listboxId = `${uniqueId}-listbox`;
 
   // ── "Add new complaint" input state ────────────────────────────────────────
   const [newComplaintInput, setNewComplaintInput] = useState("");
@@ -245,9 +246,9 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
               setPopoverOpen(true);
             }}
             onBlur={() => {/* intentionally empty — popover handles close */ }}
-            // C3: Pass down ARIA properties to bind them directly on the input element
-            inputId={INPUT_ID}
-            listboxId={LISTBOX_ID}
+            // Pass down ARIA properties to bind them directly on the input element
+            inputId={inputId}
+            listboxId={listboxId}
             popoverOpen={popoverOpen}
             focusedIndex={focusedIndex}
           />
@@ -270,11 +271,11 @@ export const ComplaintSelector: React.FC<ComplaintSelectorProps> = ({
         onSelect={handleCatalogSelect}
         onClose={handlePopoverClose}
         existingIds={catalogExistingIds}
-        // C3: Pass down state and callback props to keep popover in sync with lifted navigation state
+        // Pass down state and callback props to keep popover in sync with lifted navigation state
         focusedIndex={focusedIndex}
-        listboxId={LISTBOX_ID}
+        listboxId={listboxId}
         onFilteredItemsChange={setFilteredCatalogItems}
-        // C3: Pass down lifted region state and setter callback
+        // Pass down lifted region state and setter callback
         selectedRegion={selectedRegion}
         onRegionChange={setSelectedRegion}
       />

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -31,6 +31,9 @@ export interface MedicalComplaint {
     doctor?: string;
     isActive: boolean;
     type: 'EXISTING' | 'NEW';
+    // Optional: set for catalog entries so region chips can filter them.
+    // Patient-level complaints (EXISTING / NEW) don't carry a region.
+    region?: string;
 }
 
 export interface Procedure {


### PR DESCRIPTION

- Refactored ComplaintSelector layout to extract the new complaint input from the scrollable area, ensuring it remains sticky and always visible at the bottom of the container.

- Added CatalogSearchPopover rendered via a Portal on document.body to avoid layout constraint collisions with parent containers.

- Implemented auto-scrolling to the bottom of the complaints checklist container (listContainerRef) when a new complaint is added, using a safe deferred scroll (setTimeout) that ignores deletions or initial mounts. Added container padding (pb-3) to prevent layout clipping.

- Closed the suggestions popover upon successful addition of an item (either via Enter, clicking the Plus button, or selecting a catalog suggestion).

- Allowed the catalog popover to re-open on input click (for already-focused elements) and input change, bypassing the limitation of onFocus.

fixes #31