### PR TITLE
feat(validation): client-side write-boundary Zod validation for intake & payment forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "snakecase-keys": "^9.0.2",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.17",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -8122,9 +8123,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "snakecase-keys": "^9.0.2",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/components/FieldError.tsx
+++ b/src/components/FieldError.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib";
+
+interface FieldErrorProps {
+  message?: string;
+  className?: string;
+}
+
+export function FieldError({ message, className }: FieldErrorProps) {
+  if (!message) return null;
+
+  return (
+    <p 
+      className={cn(
+        "text-red-500 text-xs mt-1 animate-in fade-in slide-in-from-top-1",
+        className
+      )}
+    >
+      {message}
+    </p>
+  );
+}

--- a/src/features/patient/NewPatientIntake/components/DemographicsSection.tsx
+++ b/src/features/patient/NewPatientIntake/components/DemographicsSection.tsx
@@ -3,6 +3,7 @@ import { Input, ToggleButton } from "./primitives"
 import { cn, formatPhone } from "@/lib"
 import type { FormData } from '../../types'
 import type { ChangeEvent } from "react"
+import { FieldError } from "@/components/FieldError"
 
 const sexes = ['M', 'F', 'X'] as const
 
@@ -12,8 +13,9 @@ type DemographicsSectionProps = Pick<FormData, 'age' | 'phone' | 'sex'> & {
     changePhone(v: FormData['phone']): void;
     changeAge(v: FormData['age']): void;
     changeSex(v: FormData['sex']): void;
+    errors?: { age?: string; phone?: string; sex?: string };
 }
-const DemographicsSection = ({ phone, age, sex, changePhone, changeAge, changeSex }: DemographicsSectionProps) => {
+const DemographicsSection = ({ phone, age, sex, changePhone, changeAge, changeSex, errors }: DemographicsSectionProps) => {
     return (
         <section className="grid grid-cols-1 sm:grid-cols-12 gap-4">
 
@@ -38,6 +40,7 @@ const DemographicsSection = ({ phone, age, sex, changePhone, changeAge, changeSe
                         className='font-mono pl-10'
                     />
                 </div>
+                <FieldError message={errors?.phone} />
             </div>
 
             {/* Age */}
@@ -53,6 +56,7 @@ const DemographicsSection = ({ phone, age, sex, changePhone, changeAge, changeSe
                     placeholder="00"
                     className="text-center"
                 />
+                <FieldError message={errors?.age} />
             </div>
 
             {/* sex */}
@@ -78,6 +82,7 @@ const DemographicsSection = ({ phone, age, sex, changePhone, changeAge, changeSe
                         </ToggleButton>
                     ))}
                 </div>
+                <FieldError message={errors?.sex} />
             </div>
         </section >
     )

--- a/src/features/patient/NewPatientIntake/components/ReferralSection.tsx
+++ b/src/features/patient/NewPatientIntake/components/ReferralSection.tsx
@@ -2,6 +2,7 @@ import { FootprintsIcon, MapPinIcon, StethoscopeIcon } from "lucide-react";
 import { ReferralButton, TextAreaWithRef } from "./primitives";
 import { useEffect, useRef } from "react";
 import type { FormData } from '../../types';
+import { FieldError } from "@/components/FieldError";
 
 // ASSUME: REFERRAL_OPTIONS is have only these options
 const REFERRAL_OPTIONS = [
@@ -16,8 +17,9 @@ type ReferralSectionProps = {
     changeReferral(val: ReferralId): void;
     doctorInfo: FormData['doctorInfo'];
     changeDoctorInfo(v: string): void;
+    errors?: { referral?: string; doctorInfo?: string };
 }
-const ReferralSection = ({ selectedReferral, changeReferral, doctorInfo, changeDoctorInfo }: ReferralSectionProps) => {
+const ReferralSection = ({ selectedReferral, changeReferral, doctorInfo, changeDoctorInfo, errors }: ReferralSectionProps) => {
 
     const referralRef = useRef<HTMLTextAreaElement>(null);
     useEffect(() => {
@@ -43,6 +45,7 @@ const ReferralSection = ({ selectedReferral, changeReferral, doctorInfo, changeD
                     </ReferralButton>
                 ))}
             </div>
+            <FieldError message={errors?.referral} />
             {(selectedReferral === 'DOCTOR') &&
                 <div>
                     <label htmlFor="referral_info" className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest my-3 block">Doctor's Info</label>
@@ -56,6 +59,7 @@ const ReferralSection = ({ selectedReferral, changeReferral, doctorInfo, changeD
                         required
                         placeholder="Enter referring doctor's information like name, number, address, etc., here..."
                     />
+                    <FieldError message={errors?.doctorInfo} />
                 </div>}
 
         </section>

--- a/src/features/patient/NewPatientIntake/index.tsx
+++ b/src/features/patient/NewPatientIntake/index.tsx
@@ -1,28 +1,19 @@
 import { useState, useReducer } from 'react';
 import ClinicalNotesBuilder from '../ClinicalNotesBuilder';
 import { type ClinicalNote } from '../types';
-import { capitalizeEachWord, deepTrimStrings, filterAge, filterAlphabetsAndSpaces, filterPhoneNumber, normalizeAddress, validateAddress, } from '@/lib';
+import { capitalizeEachWord, deepTrimStrings, filterAge, filterAlphabetsAndSpaces, filterPhoneNumber, normalizeAddress } from '@/lib';
 import { Input, IntakeLayout, TextArea, } from './components/primitives';
 import FormHeader from './components/FormHeader';
 import ReferralSection from './components/ReferralSection';
 import DemographicsSection from './components/DemographicsSection';
 import FormFooter from './components/FormFooter';
 import type { FormData } from '../types';
+import { validatePatientIntake } from './validation';
+import { FieldError } from '@/components/FieldError';
 
 const validateAndCapitalizeName = (val: string) => capitalizeEachWord(filterAlphabetsAndSpaces(val))
 
-const validateFormData = (data: FormData): string[] => {
-    const errors = []
-    if (data.name.length < 5) errors.push('Name is too short');
-    if (data.phone.length < 10) errors.push('Phone is required');
-    if (isNaN(+data.age)|| +data.age < 0 || +data.age > 99) errors.push('Enter valid age');
-    if (!validateAddress(data.address)) errors.push('Address is invalid or too short');
-    if (data.address.length > 50) errors.push('Address is too long');
-    if (data.referral === 'DOCTOR' && !validateAddress(data.doctorInfo)) {
-        errors.push('Doctor information is required for doctor referrals');
-    }
-    return errors; // Valid if empty
-}
+
 
 interface IntakeProps {
     initialName?: string;
@@ -112,9 +103,11 @@ export const NewPatientIntake: React.FC<IntakeProps> = ({ initialName = '', onCl
     const [formData, dispatch] = useReducer(formReducer, initialFormData, initializeName);
 
     const [showClinicalNotes, setShowClinicalNotes] = useState(false)
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
 
     const handleCancel = ()=>{
         dispatch({ type: 'RESET' })
+        setFieldErrors({})
         onClose()
     }
     
@@ -122,12 +115,16 @@ export const NewPatientIntake: React.FC<IntakeProps> = ({ initialName = '', onCl
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        const errors = validateFormData(formData);
-        if (errors.length > 0) return alert(errors.join('\n'))
+        const result = validatePatientIntake(formData);
+        if (!result.success) {
+            setFieldErrors(result.fieldErrors!);
+            return;
+        }
 
         const trimmedForm = deepTrimStrings(formData) as FormData
         alert(`Creating Profile for: ${trimmedForm.name}\nMobile: ${trimmedForm.phone}\nGender: ${trimmedForm.sex}\nAddress: ${trimmedForm.address}`);
         dispatch({ type: 'RESET' })
+        setFieldErrors({})
         onSubmit(trimmedForm);
     };
 
@@ -141,7 +138,11 @@ export const NewPatientIntake: React.FC<IntakeProps> = ({ initialName = '', onCl
                 {/* ROW 1: NAME */}
                 <NameInput
                     patientName={formData.name}
-                    changeName={(value) => dispatch({ type: 'CHANGE_NAME', value })}
+                    changeName={(value) => {
+                        setFieldErrors(prev => ({ ...prev, name: '' }));
+                        dispatch({ type: 'CHANGE_NAME', value });
+                    }}
+                    error={fieldErrors.name}
                 />
 
                 {/* ROW 2: VITAL DEMOGRAPHICS  */}
@@ -149,22 +150,43 @@ export const NewPatientIntake: React.FC<IntakeProps> = ({ initialName = '', onCl
                     age={formData.age}
                     phone={formData.phone}
                     sex={formData.sex}
-                    changeAge={(value) => dispatch({ type: 'CHANGE_AGE', value })}
-                    changePhone={(value) => dispatch({ type: 'CHANGE_PHONE', value })}
-                    changeSex={(value) => dispatch({ type: 'CHANGE_SEX', value })}
+                    changeAge={(value) => {
+                        setFieldErrors(prev => ({ ...prev, age: '' }));
+                        dispatch({ type: 'CHANGE_AGE', value });
+                    }}
+                    changePhone={(value) => {
+                        setFieldErrors(prev => ({ ...prev, phone: '' }));
+                        dispatch({ type: 'CHANGE_PHONE', value });
+                    }}
+                    changeSex={(value) => {
+                        setFieldErrors(prev => ({ ...prev, sex: '' }));
+                        dispatch({ type: 'CHANGE_SEX', value });
+                    }}
+                    errors={{ age: fieldErrors.age, phone: fieldErrors.phone, sex: fieldErrors.sex }}
                 />
 
                 <AddressArea
                     address={formData.address}
-                    changeAddress={(value) => dispatch({ type: 'CHANGE_ADDRESS', value })}
+                    changeAddress={(value) => {
+                        setFieldErrors(prev => ({ ...prev, address: '' }));
+                        dispatch({ type: 'CHANGE_ADDRESS', value });
+                    }}
+                    error={fieldErrors.address}
                 />
 
                 {/* ROW 3: REFERRAL */}
                 <ReferralSection
                     doctorInfo={formData.doctorInfo}
                     selectedReferral={formData.referral}
-                    changeReferral={(value: FormData['referral']) => dispatch({ type: 'CHANGE_REFERRAL', value })}
-                    changeDoctorInfo={(value) => dispatch({ type: "CHANGE_DOCTOR_INFO", value })}
+                    changeReferral={(value: FormData['referral']) => {
+                        setFieldErrors(prev => ({ ...prev, referral: '' }));
+                        dispatch({ type: 'CHANGE_REFERRAL', value });
+                    }}
+                    changeDoctorInfo={(value) => {
+                        setFieldErrors(prev => ({ ...prev, doctorInfo: '' }));
+                        dispatch({ type: "CHANGE_DOCTOR_INFO", value });
+                    }}
+                    errors={{ referral: fieldErrors.referral, doctorInfo: fieldErrors.doctorInfo }}
                 />
 
                 {/* FOOTER ACTIONS */}
@@ -194,9 +216,10 @@ export default NewPatientIntake;
 
 type NameInputProps = {
     patientName: FormData['name'],
-    changeName(v: FormData['name']): void
+    changeName(v: FormData['name']): void,
+    error?: string
 }
-const NameInput = ({ patientName, changeName }: NameInputProps) => (
+const NameInput = ({ patientName, changeName, error }: NameInputProps) => (
     <div>
         <label className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2 block">Full Legal Name</label>
         <Input
@@ -208,13 +231,15 @@ const NameInput = ({ patientName, changeName }: NameInputProps) => (
             className="text-xl font-medium"
             autoFocus
         />
+        <FieldError message={error} />
     </div>
 )
 type AddressAreaProps = {
     address: string;
     changeAddress(v: string): void;
+    error?: string;
 }
-const AddressArea = ({ address, changeAddress }: AddressAreaProps) => (
+const AddressArea = ({ address, changeAddress, error }: AddressAreaProps) => (
     <section>
         <label htmlFor="address" className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest my-3 block">Address</label>
 
@@ -227,6 +252,7 @@ const AddressArea = ({ address, changeAddress }: AddressAreaProps) => (
             value={address}
             onChange={(e) => changeAddress(e.currentTarget.value)}
         />
+        <FieldError message={error} />
     </section>
 )
 

--- a/src/features/patient/NewPatientIntake/validation.ts
+++ b/src/features/patient/NewPatientIntake/validation.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { DB_GENDER, DB_REFERRAL_MODE } from '@/lib/validation/db-enums';
+
+// The FormData type uses 'sex' and 'referral' which map to 'gender' and 'referral_mode' in the DB.
+// We validate the form fields exactly as they are named in the FormData type.
+// The mapping to DB column names happens at the DTO/API layer.
+const patientIntakeSchema = z.object({
+  name: z.string().min(5, 'Name is too short'),
+  phone: z.string().min(10, 'Phone number is required'),
+  sex: z.enum(DB_GENDER, { message: 'Gender must be M, F, or X' }),
+  age: z.string().refine((val) => {
+    const num = Number(val);
+    return !isNaN(num) && num >= 0 && num <= 99 && val.trim() !== '';
+  }, { message: 'Enter a valid age' }),
+  address: z.string().min(3, 'Address is invalid or too short').max(50, 'Address is too long'),
+  referral: z.enum(DB_REFERRAL_MODE, { message: 'Referral source must be Walk-in, Google, or Doctor' }),
+  doctorInfo: z.string().optional(),
+  clinicalNotes: z.array(z.any()).optional(),
+}).superRefine((data, ctx) => {
+  if (data.referral === 'DOCTOR') {
+    if (!data.doctorInfo || data.doctorInfo.trim().length < 3) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Referral doctor details are required when referral source is Doctor',
+        path: ['doctorInfo'],
+      });
+    }
+  }
+}).transform((data) => {
+  if (data.referral !== 'DOCTOR') {
+    data.doctorInfo = undefined;
+  }
+  return data;
+});
+
+export function validatePatientIntake(data: any) {
+  const result = patientIntakeSchema.safeParse(data);
+  if (result.success) {
+    return { success: true };
+  } else {
+    const fieldErrors: Record<string, string> = {};
+    for (const issue of result.error.issues) {
+      const path = issue.path[0] as string;
+      if (path && !fieldErrors[path]) {
+        fieldErrors[path] = issue.message;
+      }
+    }
+    return { success: false, fieldErrors };
+  }
+}

--- a/src/features/visit/InvoiceBuilder/components/FooterActions.tsx
+++ b/src/features/visit/InvoiceBuilder/components/FooterActions.tsx
@@ -1,30 +1,75 @@
 import { cn } from "@/lib";
 import { PrinterIcon } from "lucide-react";
+import { useState } from "react";
+import type { PaymentMode } from "./PaymentSelector";
+import type { InvoicePaymentPayload } from "../index";
+import { validateInvoicePayment } from "../validation";
 
-export const FooterActions = ({ onClose, isEmpty }: { onClose(): void, isEmpty: boolean }) => (<div className="flex justify-between items-center pt-4 border-t border-zinc-200 dark:border-zinc-800">
-    <button className="text-zinc-500 hover:text-zinc-900 dark:hover:text-white flex items-center gap-2 text-sm transition-colors"
-        onClick={() => alert("Yet to be implemented")}
-    >
-        <PrinterIcon className="w-4 h-4" /> Print Receipt
-    </button>
-    <button
-        onClick={onClose}
-        type="button"
-        disabled={isEmpty}
-        className={cn(
-            "px-6 py-2",
-            "bg-emerald-600 hover:bg-emerald-700",
-            "dark:bg-emerald-700 dark:hover:bg-emerald-600",
-            "disabled:bg-zinc-200 disabled:dark:bg-zinc-800",
-            "disabled:text-zinc-400 disabled:dark:text-zinc-600",
-            "disabled:shadow-none disabled:cursor-not-allowed",
-            "hover:disabled:bg-zinc-200 dark:hover:disabled:bg-zinc-800",
-            "hover:disabled:bg-emerald-200 dark:hover:disabled:bg-emerald-900/40",
-            "text-white font-bold rounded transition-colors shadow-md"
-        )}
-    >
-        Confirm Payment
-    </button>
-</div>)
+interface FooterActionsProps {
+    onClose: () => void;
+    isEmpty: boolean;
+    paymentMode?: PaymentMode;
+    onConfirm?: (payload: InvoicePaymentPayload) => void;
+}
+
+export const FooterActions = ({ onClose, isEmpty, paymentMode, onConfirm }: FooterActionsProps) => {
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const handleConfirm = () => {
+        if (!paymentMode) return;
+        
+        // On "Confirm Payment" click: paymentStatus should default to 'Paid'
+        const payload = { paymentMode, paymentStatus: 'Paid' };
+        
+        const validation = validateInvoicePayment(payload);
+        if (!validation.success && validation.fieldErrors) {
+            setErrors(validation.fieldErrors);
+            return;
+        }
+        
+        setErrors({});
+        if (onConfirm) {
+            onConfirm(payload as InvoicePaymentPayload);
+        } else {
+            // Fallback for backwards compatibility
+            onClose();
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-2 pt-4 border-t border-zinc-200 dark:border-zinc-800">
+            {Object.keys(errors).length > 0 && (
+                <div className="text-red-500 text-xs font-medium px-1 text-right">
+                    {Object.values(errors)[0]}
+                </div>
+            )}
+            <div className="flex justify-between items-center">
+                <button className="text-zinc-500 hover:text-zinc-900 dark:hover:text-white flex items-center gap-2 text-sm transition-colors"
+                    onClick={() => alert("Yet to be implemented")}
+                >
+                    <PrinterIcon className="w-4 h-4" /> Print Receipt
+                </button>
+                <button
+                    onClick={handleConfirm}
+                    type="button"
+                    disabled={isEmpty}
+                    className={cn(
+                        "px-6 py-2",
+                        "bg-emerald-600 hover:bg-emerald-700",
+                        "dark:bg-emerald-700 dark:hover:bg-emerald-600",
+                        "disabled:bg-zinc-200 disabled:dark:bg-zinc-800",
+                        "disabled:text-zinc-400 disabled:dark:text-zinc-600",
+                        "disabled:shadow-none disabled:cursor-not-allowed",
+                        "hover:disabled:bg-zinc-200 dark:hover:disabled:bg-zinc-800",
+                        "hover:disabled:bg-emerald-200 dark:hover:disabled:bg-emerald-900/40",
+                        "text-white font-bold rounded transition-colors shadow-md"
+                    )}
+                >
+                    Confirm Payment
+                </button>
+            </div>
+        </div>
+    );
+};
 
 export default FooterActions;

--- a/src/features/visit/InvoiceBuilder/index.tsx
+++ b/src/features/visit/InvoiceBuilder/index.tsx
@@ -8,16 +8,21 @@ import PaymentSelector from "./components/PaymentSelector";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
+export interface InvoicePaymentPayload {
+    paymentMode: PaymentMode;
+    paymentStatus: string;
+    totalInPaise?: number;
+}
 
-interface InvoiceBuilderProps {
+export interface InvoiceBuilderProps {
     items: InvoiceItem[];
     patientName: string;
     invoiceNumber: string; // Caller owns ID generation — component shouldn't hardcode this
     onClose: () => void;
+    onConfirm?: (payload: InvoicePaymentPayload) => void;
 }
 
-
-const InvoiceBuilder: React.FC<InvoiceBuilderProps> = ({ items, patientName, invoiceNumber, onClose }) => {
+const InvoiceBuilder: React.FC<InvoiceBuilderProps> = ({ items, patientName, invoiceNumber, onClose, onConfirm }) => {
     const [paymentMode, setPaymentMode] = useState<PaymentMode>('UPI');
 
     const total = items.reduce((sum, i) => sum + i.cost, 0);
@@ -42,7 +47,12 @@ const InvoiceBuilder: React.FC<InvoiceBuilderProps> = ({ items, patientName, inv
                 <PaymentSelector paymentMode={paymentMode} setPaymentMode={setPaymentMode}/>
 
                 {/* Actions */}
-                <FooterActions onClose={onClose} isEmpty={isEmpty} />
+                <FooterActions 
+                    onClose={onClose} 
+                    isEmpty={isEmpty} 
+                    paymentMode={paymentMode}
+                    onConfirm={onConfirm}
+                />
 
             </div>
         </div >

--- a/src/features/visit/InvoiceBuilder/validation.ts
+++ b/src/features/visit/InvoiceBuilder/validation.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { DB_PAYMENT_MODE_MVP, DB_PAYMENT_STATUS } from '@/lib/validation/db-enums';
+
+// payment_mode has NO CHECK constraint in schema.sql.
+// These values come from clinics.payment_methods_accepted default array ['CASH', 'UPI', 'CARD'].
+// We hardcode the default set as a pragmatic MVP choice.
+export const invoicePaymentSchema = z.object({
+    paymentMode: z.enum(DB_PAYMENT_MODE_MVP),
+    paymentStatus: z.enum(DB_PAYMENT_STATUS),
+});
+
+export function validateInvoicePayment(data: { paymentMode: string; paymentStatus: string }) {
+    const result = invoicePaymentSchema.safeParse(data);
+    if (result.success) {
+        return { success: true };
+    }
+    const fieldErrors: Record<string, string> = {};
+    const errors = result.error.flatten().fieldErrors;
+    if (errors.paymentMode?.length) {
+        fieldErrors.paymentMode = errors.paymentMode[0];
+    }
+    if (errors.paymentStatus?.length) {
+        fieldErrors.paymentStatus = errors.paymentStatus[0];
+    }
+    return { success: false, fieldErrors };
+}

--- a/src/lib/validation/db-enums.ts
+++ b/src/lib/validation/db-enums.ts
@@ -1,0 +1,12 @@
+// These constants mirror the CHECK constraints in schema.sql (v11).
+// If a constraint changes in the DB, update the single source of truth here.
+export const DB_GENDER = ['M', 'F', 'X'] as const;
+export const DB_REFERRAL_MODE = ['WALKIN', 'GOOGLE', 'DOCTOR'] as const;
+export const DB_VISIT_TYPE = ['CONSULTATION', 'MACHINE_ONLY'] as const;
+export const DB_CONSULTATION_TYPE = ['FIRST', 'SUBSEQUENT'] as const;
+// payment_status uses Title case per schema CHECK constraint
+export const DB_PAYMENT_STATUS = ['Paid', 'Pending', 'Overdue'] as const;
+// payment_mode has NO CHECK constraint in schema.sql.
+// These values come from clinics.payment_methods_accepted default.
+// Hardcoded here as pragmatic MVP — real implementation should fetch per-clinic config.
+export const DB_PAYMENT_MODE_MVP = ['CASH', 'UPI', 'CARD'] as const;

--- a/src/pages/vistitworkflow.tsx
+++ b/src/pages/vistitworkflow.tsx
@@ -150,6 +150,7 @@ const VisitWorkflow = () => {
                     ].slice(0)}
                     patientName="Amitabh Bachchan"
                     onClose={() => alert('Visit Closed')}
+                    onConfirm={(payload) => { console.log('Payment confirmed:', payload); alert(`Payment confirmed via ${payload.paymentMode}`); }}
                 />
             </PresentationSection>
         </>


### PR DESCRIPTION

## Summary of Changes
This PR introduces client-side Zod write-boundary validation for forms, ensuring payloads strictly comply with PostgreSQL `schema.sql` (v11) `CHECK` constraints and enums *before* hitting the backend.

### 1. Shared Validation Layer
- **`src/lib/validation/db-enums.ts`**: Single source of truth mirroring DB CHECK constraints and enums (`DB_GENDER`, `DB_REFERRAL_MODE`, `DB_VISIT_TYPE`, `DB_CONSULTATION_TYPE`, `DB_PAYMENT_STATUS`, `DB_PAYMENT_MODE_MVP`).
- **`src/components/FieldError.tsx`**: Reusable inline error message component with dark mode support and subtle slide/fade animation.

### 2. Patient Intake Form (`NewPatientIntake`)
- **`src/features/patient/NewPatientIntake/validation.ts`**: Zod schema validating:
  - `sex`: `z.enum(['M', 'F', 'X'])` (maps to DB `patients.gender`).
  - `referral`: `z.enum(['WALKIN', 'GOOGLE', 'DOCTOR'])` (maps to DB `patients.referral_mode`).
  - `doctorInfo`: Conditional validation via `.superRefine()` requiring doctor details when `referral === 'DOCTOR'`; stripped automatically via `.transform()` when not `'DOCTOR'` (enforcing schema `NULL` constraint).
  - Basic fields: `name` (min 5), `phone` (min 10), `age` (0-99 numeric string), `address` (3-50 chars).
- **Inline UI**: Replaced native browser `alert()` calls in `index.tsx` with inline `<FieldError>` components under inputs, clearing errors dynamically `onChange`.

### 3. Invoice Payment Form (`InvoiceBuilder`)
- **Plumbing Fix**: Wired `paymentMode` state from `InvoiceBuilder` through `FooterActions` into the payment confirmation payload.
- **`src/features/visit/InvoiceBuilder/validation.ts`**: Zod schema validating:
  - `paymentMode`: `z.enum(['CASH', 'UPI', 'CARD'])` (hardcoded default set as pragmatic MVP choice).
  - `paymentStatus`: Title-case `z.enum(['Paid', 'Pending', 'Overdue'])` matching `invoices.payment_status CHECK`.
- **Submit Flow**: `FooterActions` validates the payload on "Confirm Payment", defaults `paymentStatus` to `'Paid'`, renders inline validation errors if invalid, and passes `{ paymentMode, paymentStatus }` to `onConfirm`.

### 4. Visit Creation (BLOCKED)
- **Status**: Flagged as BLOCKED. No form currently composes a `Visit` payload or presents UI for `visit_type` (`'CONSULTATION'` vs `'MACHINE_ONLY'`) or `consultation_type` (`'FIRST'` vs `'SUBSEQUENT'`).
- **Infrastructure Ready**: `DB_VISIT_TYPE` and `DB_CONSULTATION_TYPE` constants are exported in `db-enums.ts` for immediate use once the visit creation form is built.

## Verification & Build
- `npx tsc --noEmit`: **Clean build (0 errors)**.
- Verified pass/fail cases for all intake fields, doctor referral conditional logic, and invoice payment confirmation.